### PR TITLE
Update app-shell.role.json.in: Add trustLevel

### DIFF
--- a/src/webos/install/app_shell/app-shell.role.json.in
+++ b/src/webos/install/app_shell/app-shell.role.json.in
@@ -1,6 +1,7 @@
 {
     "exeName": "/usr/bin/app-shell/app_shell",
     "type": "privileged",
+    "trustLevel": "oem",
     "allowedNames": [
         "com.webos.app.enactbrowser",
         "com.webos.chromium.audio-*",


### PR DESCRIPTION
Fixes:

Sep 27 07:51:47 qemux86-64 ls-hubd[290]: [] [pmlog] ls-hubd LSHUB_ROLE_FILE {"FILE":"file_parser.cpp","LINE":195} No trust level specified for application in role file (/usr/share/luna-service2/roles.d/app-shell.role.json)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>